### PR TITLE
docs(workflow): mark mirror-release.yml as manual fallback

### DIFF
--- a/.github/workflows/mirror-release.yml
+++ b/.github/workflows/mirror-release.yml
@@ -1,7 +1,19 @@
 name: Mirror release from Parslee-ai/car
 
-# Manually triggered. Downloads all assets from a tag in the private
-# Parslee-ai/car repo and publishes them here as a public release.
+# MANUAL FALLBACK ONLY.
+#
+# The primary, automated mirror lives in the private repo:
+#   Parslee-ai/car -> .github/workflows/build.yml -> job `mirror-to-car-releases`
+# That job runs on every `v*` tag push and copies every asset into this repo's
+# GitHub Releases automatically. 99% of the time you do not need this workflow.
+#
+# Use this manual workflow when:
+#   - Backfilling a tag that predates the auto-mirror job (e.g. v0.4.1-v0.4.3).
+#   - Re-mirroring a tag after the auto-mirror job failed (expired PAT,
+#     network flake, partial upload). Re-running here is safe — `gh release
+#     create` will refuse to clobber, so delete the broken release first or
+#     swap to `gh release upload --clobber` manually.
+#   - Ad-hoc cleanup / asset replacement for an already-published tag.
 #
 # Requires a repo secret MIRROR_TOKEN — a PAT with `repo` scope on the
 # private Parslee-ai/car repository.

--- a/README.md
+++ b/README.md
@@ -562,6 +562,15 @@ CAR is pre-1.0. Breaking changes between minor versions are possible — pin to
 exact versions until the API stabilizes. Each release lists breaking changes
 in the GitHub release notes.
 
+## Releases
+
+Releases in this repo are auto-mirrored from the private `Parslee-ai/car`
+source repo via its `.github/workflows/build.yml` workflow (job
+`mirror-to-car-releases`), which runs on every `v*` tag push. The manual
+`mirror-release.yml` workflow in this repo is a fallback for backfilling
+older tags or recovering from a failed auto-mirror — it is not the primary
+path.
+
 ## Issues
 
 Report binary-side problems (install, crashes, platform support, docs) on


### PR DESCRIPTION
## Summary

- `mirror-release.yml` is no longer the primary mirror path. Documented it as a manual fallback.
- The auto-mirror now lives in `Parslee-ai/car` -> `.github/workflows/build.yml` -> job `mirror-to-car-releases`, which runs on every `v*` tag push automatically.
- Added a header comment to this workflow and a short "Releases" section in README.

## Why

For v0.4.1-v0.4.3 the manual `workflow_dispatch` here was never triggered, so `install.js` 404'd fetching binaries from this repo. Automating the mirror on the source side (`Parslee-ai/car`) removes the human step.

This workflow stays in place for edge cases:
- Backfilling an older tag that predates auto-mirror.
- Recovering from a failed auto-mirror (expired PAT, etc.).
- Ad-hoc asset cleanup.

No behavior change; documentation only.

## Plan reference

`docs/plans/2026-04-21-001-fix-car-runtime-install-surface-plan.md` — Unit 4.

## Test plan

- [ ] Review the header comment block on `mirror-release.yml` for clarity.
- [ ] Review the new "Releases" section in `README.md`.
- [ ] Confirm YAML still parses (no `name:` / `on:` / `jobs:` structural changes).