### PR TITLE
license: make Apache-2.0 machine-detectable; split binary terms

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,65 +1,4 @@
-Common Agent Runtime — License
-==============================
 
-This repository's contents fall under two different licenses. The applicable
-license depends on the file.
-
-
-1. BINARIES — free to use and redistribute, NOT free to modify
----------------------------------------------------------------
-
-Applies to: the compiled artifacts distributed via GitHub Releases on this
-repository — platform tarballs (car-*.tar.gz), Node.js native modules
-(car-runtime.*.node), Python wheels (car_runtime-*.whl), the CLI binaries
-they contain (car, car-server, car-memgine-eval), and any other pre-built
-binary shipped under this repository's releases.
-
-Copyright © 2026 Parslee AI. All rights reserved.
-
-Subject to your agreement with these terms, Parslee AI grants you a
-worldwide, royalty-free, non-exclusive, non-transferable license to:
-
-  (a) download, install, and use the Binaries for any lawful purpose,
-      including commercial use;
-  (b) redistribute the Binaries in their original, unmodified form,
-      provided this license is included.
-
-You may NOT:
-
-  (c) modify, translate, adapt, or create derivative works of the Binaries;
-  (d) decompile, disassemble, reverse engineer, or otherwise attempt to
-      derive the source code of the Binaries, except to the extent that
-      applicable law expressly permits despite this limitation;
-  (e) remove, alter, or obscure any copyright, trademark, or other
-      proprietary notices on or in the Binaries;
-  (f) circumvent or disable any license-enforcement, anti-tamper, or
-      similar mechanism in the Binaries.
-
-If you need rights beyond those granted above — including modification,
-derivative works, source access, or a commercial redistribution agreement —
-contact Parslee AI.
-
-THE BINARIES ARE PROVIDED "AS IS" AND WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL
-PARSLEE AI BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY ARISING
-FROM THE USE OF, INABILITY TO USE, OR DISTRIBUTION OF THE BINARIES.
-
-
-2. REPOSITORY CONTENTS (documentation, examples, scripts) — Apache-2.0
-----------------------------------------------------------------------
-
-Applies to: the text files in this repository — README.md, CHANGELOG.md,
-the `examples/` directory, install and mirror scripts, workflow files, and
-any other source published under this repository's git tree (EXCLUDING the
-Binaries described in Section 1).
-
-These files are licensed under the Apache License, Version 2.0. The full
-text is reproduced below. You may copy, modify, and redistribute them
-under those terms.
-
-
-================================================================================
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -199,8 +138,8 @@ under those terms.
 
    6. Trademarks. This License does not grant permission to use the trade
       names, trademarks, service marks, or product names of the Licensor,
-      except as required for describing the origin of the Work and
-      reproducing the content of the NOTICE file.
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
    7. Disclaimer of Warranty. Unless required by applicable law or
       agreed to in writing, Licensor provides the Work (and each
@@ -224,7 +163,7 @@ under those terms.
       other commercial damages or losses), even if such Contributor
       has been advised of the possibility of such damages.
 
-   9. Accepting Warranty or Support. While redistributing
+   9. Accepting Warranty or Additional Liability. While redistributing
       the Work or Derivative Works thereof, You may choose to offer,
       and charge a fee for, acceptance of support, warranty, indemnity,
       or other liability obligations and/or rights consistent with this
@@ -233,9 +172,20 @@ under those terms.
       of any other Contributor, and only if You agree to indemnify,
       defend, and hold each Contributor harmless for any liability
       incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or support.
+      of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
 
    Copyright 2026 Parslee AI
 

--- a/LICENSE-BINARIES
+++ b/LICENSE-BINARIES
@@ -1,0 +1,48 @@
+Common Agent Runtime — Binary License
+=====================================
+
+This file governs the COMPILED BINARIES distributed via this repository's
+GitHub Releases. The repository's own source contents (README, examples,
+scripts, workflows, manifests) are licensed separately under Apache-2.0 —
+see the LICENSE file.
+
+
+BINARIES — free to use and redistribute, NOT free to modify
+-----------------------------------------------------------
+
+Applies to: the compiled artifacts distributed via GitHub Releases on this
+repository — platform tarballs (car-*.tar.gz), Node.js native modules
+(car-runtime.*.node), Python wheels (car_runtime-*.whl), the CLI binaries
+they contain (car, car-server, car-memgine-eval), and any other pre-built
+binary shipped under this repository's releases.
+
+Copyright © 2026 Parslee AI. All rights reserved.
+
+Subject to your agreement with these terms, Parslee AI grants you a
+worldwide, royalty-free, non-exclusive, non-transferable license to:
+
+  (a) download, install, and use the Binaries for any lawful purpose,
+      including commercial use;
+  (b) redistribute the Binaries in their original, unmodified form,
+      provided this license is included.
+
+You may NOT:
+
+  (c) modify, translate, adapt, or create derivative works of the Binaries;
+  (d) decompile, disassemble, reverse engineer, or otherwise attempt to
+      derive the source code of the Binaries, except to the extent that
+      applicable law expressly permits despite this limitation;
+  (e) remove, alter, or obscure any copyright, trademark, or other
+      proprietary notices on or in the Binaries;
+  (f) circumvent or disable any license-enforcement, anti-tamper, or
+      similar mechanism in the Binaries.
+
+If you need rights beyond those granted above — including modification,
+derivative works, source access, or a commercial redistribution agreement —
+contact Parslee AI.
+
+THE BINARIES ARE PROVIDED "AS IS" AND WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL
+PARSLEE AI BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY ARISING
+FROM THE USE OF, INABILITY TO USE, OR DISTRIBUTION OF THE BINARIES.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,18 @@
+Common Agent Runtime (CAR)
+Copyright © 2026 Parslee AI
+
+This repository uses two licenses:
+
+  * Repository SOURCE contents (README, CHANGELOG, examples/, install and
+    mirror scripts, workflows, winget/Scoop manifests, and any other source
+    under this git tree) are licensed under the Apache License, Version 2.0.
+    See LICENSE.
+
+  * The compiled BINARIES distributed via this repository's GitHub Releases
+    (car-*.tar.gz, car-runtime.*.node, car_runtime-*.whl, and the car /
+    car-server / car-memgine-eval executables) are proprietary: free to use
+    and redistribute unmodified, but not to modify or reverse engineer.
+    Source for the binaries is not published. See LICENSE-BINARIES.
+
+For rights beyond those — source access, modification, or a commercial
+redistribution agreement — contact Parslee AI.

--- a/README.md
+++ b/README.md
@@ -708,15 +708,17 @@ available under separate terms — see License below.
 
 ## License
 
-Two licenses, depending on what you're using — see [LICENSE](./LICENSE) for the
-authoritative text.
+Two licenses, depending on what you're using — see [NOTICE](./NOTICE) for the
+summary and the two license files for the authoritative text.
 
+- **Repository contents** (README, examples, install scripts, workflows,
+  manifests) — **Apache-2.0**. Copy, modify, and reuse freely. See
+  [LICENSE](./LICENSE).
 - **Binaries** (tarballs, wheels, `.node` modules, CLI) — free for any use
   including commercial, free to redistribute unmodified. Modification, reverse
   engineering, and derivative works are not permitted. Copyright © 2026
-  Parslee AI. Source is not published under an open license.
-- **Repository contents** (README, examples, install scripts, workflows) —
-  Apache-2.0. Copy, modify, and reuse freely.
+  Parslee AI. Source is not published under an open license. See
+  [LICENSE-BINARIES](./LICENSE-BINARIES).
 
 If you need terms beyond those — source access, modification rights, a
 commercial redistribution agreement — contact Parslee AI.


### PR DESCRIPTION
@mliotta — following your call on #248 ("car-releases can be under an OSS license… apache… you get everything including the binaries, but no source for the binaries"). This makes that intent **machine-detectable** without changing any actual rights.

## The problem
The license lived in one custom dual-license file, so GitHub classified the repo as **"Other" (NOASSERTION)**, not Apache-2.0. The SignPath OSS signing application (#248) and the winget submission (#296) both need GitHub/tooling to *see* an OSI-approved license on the public repo. A custom combined file doesn't trip the detector.

## The fix (intent unchanged)
| File | What |
|------|------|
| `LICENSE` | Now **pure, standard Apache-2.0** text → GitHub's Licensee detector will recognize the repo as Apache-2.0. Body verified to match the canonical apache.org text **exactly**. |
| `LICENSE-BINARIES` | The proprietary binary terms, **verbatim** from the old `LICENSE` Section 1 (use/redistribute unmodified; no modification, RE, or derivative works; AS-IS). |
| `NOTICE` | Short summary of the two-license split (standard Apache convention). |
| `README` | License section points at all three; wording otherwise unchanged. |

**No rights change.** Binaries stay proprietary, repo source stays Apache-2.0 — this only restructures so the Apache part is detectable.

## After merge
- GitHub will show **Apache-2.0** on `Parslee-ai/car-releases` (helps the SignPath OSS review land).
- The winget PR (microsoft/winget-pkgs#388307) currently declares `License: Proprietary` for the package; we can leave that (it describes the *binary*, which is accurate) or revisit.

Refs #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)